### PR TITLE
Migrate to the latest plugin APIs

### DIFF
--- a/android/src/main/kotlin/com/freelancer/media_file_saver/MediaFileSaverDelegate.kt
+++ b/android/src/main/kotlin/com/freelancer/media_file_saver/MediaFileSaverDelegate.kt
@@ -1,21 +1,53 @@
 package com.freelancer.media_file_saver
 
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
 import android.content.pm.PackageManager
-import com.freelancer.media_file_saver.MediaFileSaverPlugin.Companion.WRITE_EXTERNAL_STORAGE_FILE
-import com.freelancer.media_file_saver.MediaFileSaverPlugin.Companion.WRITE_EXTERNAL_STORAGE_IMAGE
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Environment
+import androidx.core.app.ActivityCompat
+import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.PluginRegistry
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 
 /**
  * Created by Joshua de Guzman on 2020-01-06.
  */
 class MediaFileSaverDelegate(
-    private val iMediaFileSaverPlugin: IMediaFileSaverPlugin
-) : PluginRegistry.RequestPermissionsResultListener {
+    private val activity: Activity
+) : PluginRegistry.RequestPermissionsResultListener,
+    PluginRegistry.ActivityResultListener {
+    private val bitmap: Bitmap? = null
+    private val filePath: String? = null
+    private var result: MethodChannel.Result? = null
+
+    companion object {
+        private const val IMAGE_QUALITY = 100
+        private const val WRITE_EXTERNAL_STORAGE_IMAGE = 1001
+        private const val WRITE_EXTERNAL_STORAGE_FILE = 1002
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode == WRITE_EXTERNAL_STORAGE_IMAGE || requestCode == WRITE_EXTERNAL_STORAGE_FILE) {
+            result?.success(if (resultCode == Activity.RESULT_OK) 0 else 1)
+            return true
+        }
+        return false
+    }
+
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray): Boolean {
+        // TODO: Add check whether the permission has been denied permanently
         when (requestCode) {
             WRITE_EXTERNAL_STORAGE_IMAGE -> {
                 if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
-                    iMediaFileSaverPlugin.onGrantExternalStorageImage()
+                    bitmap?.let {
+                        saveImage(it)
+                    }
                 } else {
                     // TODO: Expose error in the channel
                 }
@@ -23,12 +55,84 @@ class MediaFileSaverDelegate(
 
             WRITE_EXTERNAL_STORAGE_FILE -> {
                 if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
-                    iMediaFileSaverPlugin.onGrantExternalStorageFile()
+                    filePath?.let {
+                        saveFile(it)
+                    }
                 } else {
                     // TODO: Expose error in the channel
                 }
             }
         }
         return true
+    }
+
+    fun checkPermissionSaveImage(image: ByteArray, result: MethodChannel.Result): String {
+        this.result = result
+        val bitmap = BitmapFactory.decodeByteArray(image, 0, image.size)
+        if (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), WRITE_EXTERNAL_STORAGE_IMAGE)
+        } else {
+            saveImage(bitmap)
+        }
+        return "Cannot continue saving the image."
+    }
+
+    fun checkPermissionSaveFile(path: String, result: MethodChannel.Result): String {
+        this.result = result
+        if (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), WRITE_EXTERNAL_STORAGE_IMAGE)
+        } else {
+            return saveFile(path)
+        }
+        return "Cannot continue saving the image."
+    }
+
+    private fun saveImage(bitmap: Bitmap): String {
+        return try {
+            val file = createFile("png")
+            val fileOutputStream = FileOutputStream(file)
+            bitmap.compress(Bitmap.CompressFormat.PNG, IMAGE_QUALITY, fileOutputStream)
+            fileOutputStream.close()
+
+            val uri = Uri.fromFile(file)
+            val context = activity.applicationContext
+            context.sendBroadcast(Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, uri))
+            uri.toString()
+        } catch (e: IOException) {
+            e.printStackTrace()
+            "Failed to save image to the gallery."
+        }
+    }
+
+
+    private fun saveFile(filePath: String): String {
+        return try {
+            val tempFile = File(filePath)
+            val file = createFile(tempFile.extension)
+            tempFile.copyTo(file)
+
+            val uri = Uri.fromFile(file)
+            val context = activity.applicationContext
+            context.sendBroadcast(Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, uri))
+            uri.toString()
+        } catch (e: IOException) {
+            e.printStackTrace()
+            "Failed to save file to the gallery."
+        }
+    }
+
+    private fun createFile(extension: String = ""): File {
+        // TODO: Expose MethodChannel to allow custom path
+        // TODO: Expose MethodChannel to allow custom extensions
+        val path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES).absolutePath
+        val directory = File(path)
+        if (!directory.exists()) {
+            directory.mkdir()
+        }
+        var fileName = System.currentTimeMillis().toString()
+        if (extension.isNotEmpty()) {
+            fileName += ("." + extension)
+        }
+        return File(directory, fileName)
     }
 }

--- a/android/src/main/kotlin/com/freelancer/media_file_saver/MediaFileSaverPlugin.kt
+++ b/android/src/main/kotlin/com/freelancer/media_file_saver/MediaFileSaverPlugin.kt
@@ -1,150 +1,86 @@
 package com.freelancer.media_file_saver
 
-import android.Manifest
-import android.app.Activity
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.net.Uri
-import android.os.Environment
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
+import android.content.Context
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.PluginRegistry.Registrar
-import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
 
-interface IMediaFileSaverPlugin {
-    fun onGrantExternalStorageImage(): String
-    fun onGrantExternalStorageFile(): String
-}
+class MediaFileSaverPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
-class MediaFileSaverPlugin(
-    private val activity: Activity,
-    private val registrar: Registrar
-) : MethodCallHandler, IMediaFileSaverPlugin {
-
-    private val IMAGE_QUALITY = 100
-
-    private val bitmap: Bitmap? = null
-    private val filePath: String? = null
+    private var context: Context? = null
+    private var binaryMessenger: BinaryMessenger? = null
+    private var methodChannel: MethodChannel? = null
+    private var registrar: Registrar? = null
+    private var mediaFileSaverPlugin: MediaFileSaverDelegate? = null
 
     companion object {
-        val WRITE_EXTERNAL_STORAGE_IMAGE = 1001
-        val WRITE_EXTERNAL_STORAGE_FILE = 1002
-
         @JvmStatic
         fun registerWith(registrar: Registrar) {
-            val channel = MethodChannel(registrar.messenger(), "com.freelancer.flutter.plugins/media_file_saver")
-            val plugin = MediaFileSaverPlugin(registrar.activity(), registrar)
-            channel.setMethodCallHandler(plugin)
-            registrar.addRequestPermissionsResultListener(MediaFileSaverDelegate(plugin))
-
+            val plugin = MediaFileSaverPlugin()
+            plugin.onAttachedToEngine(registrar.context(), registrar.messenger(), registrar)
         }
     }
 
-    override fun onMethodCall(call: MethodCall, result: Result): Unit {
+    override fun onMethodCall(call: MethodCall, result: Result) {
         when {
-            call.method == "saveImage" -> {
+            call.method == MediaFileSaverPluginMethodChannel.SAVE_IMAGE.toString() -> {
                 val image = call.arguments as ByteArray
-                result.success(checkPermissionSaveImage(BitmapFactory.decodeByteArray(image, 0, image.size)))
+                this.mediaFileSaverPlugin?.checkPermissionSaveImage(image, result)
             }
-            call.method == "saveFile" -> {
+            call.method == MediaFileSaverPluginMethodChannel.SAVE_FILE.toString() -> {
                 val path = call.arguments as String
-                result.success(checkPermissionSaveFile(path))
+                this.mediaFileSaverPlugin?.checkPermissionSaveFile(path, result)
             }
             else -> result.notImplemented()
         }
     }
 
-    override fun onGrantExternalStorageImage(): String {
-        return if (bitmap != null) {
-            saveImage(bitmap)
-        } else {
-            "Bitmap cannot be null"
+    private fun onAttachedToEngine(context: Context, binaryMessenger: BinaryMessenger, registrar: Registrar? = null) {
+        this.context = context
+        this.binaryMessenger = binaryMessenger
+        this.methodChannel = MethodChannel(binaryMessenger, "com.freelancer.flutter.plugins/media_file_saver")
+        this.methodChannel?.setMethodCallHandler(this)
+        registrar?.let {
+            this.registrar = it
         }
     }
 
-    override fun onGrantExternalStorageFile(): String {
-        return if (filePath != null) {
-            saveFile(filePath)
-        } else {
-            "File path cannot be null"
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        onAttachedToEngine(binding.applicationContext, binding.binaryMessenger)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        // TODO
+    }
+
+    override fun onDetachedFromActivity() {
+        this.mediaFileSaverPlugin = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        this.mediaFileSaverPlugin = null
+        this.mediaFileSaverPlugin = MediaFileSaverDelegate(binding.activity)
+        this.mediaFileSaverPlugin?.let {
+            registrar?.addRequestPermissionsResultListener(it)
+            registrar?.addActivityResultListener(it)
         }
     }
 
-    private fun checkPermissionSaveImage(bitmap: Bitmap): String {
-        // TODO: Add check whether the permission has been denied permanently
-        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            // Request permission
-            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), WRITE_EXTERNAL_STORAGE_IMAGE)
-        } else {
-            return saveImage(bitmap)
-        }
-        return "Cannot continue saving the image."
-    }
-
-    private fun saveImage(bitmap: Bitmap): String {
-        return try {
-            val file = createFile("png")
-            val fileOutputStream = FileOutputStream(file)
-            bitmap?.compress(Bitmap.CompressFormat.PNG, IMAGE_QUALITY, fileOutputStream)
-            fileOutputStream.close()
-
-            val uri = Uri.fromFile(file)
-            val context = registrar.activeContext().applicationContext
-            context.sendBroadcast(Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, uri))
-            uri.toString()
-        } catch (e: IOException) {
-            e.printStackTrace()
-            "Failed to save image to the gallery."
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        this.mediaFileSaverPlugin = MediaFileSaverDelegate(binding.activity)
+        this.mediaFileSaverPlugin?.let {
+            registrar?.addRequestPermissionsResultListener(it)
+            registrar?.addActivityResultListener(it)
         }
     }
 
-    private fun checkPermissionSaveFile(filePath: String): String {
-        // TODO: Add check whether the permission has been denied permanently
-        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            // Request permission
-            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), WRITE_EXTERNAL_STORAGE_IMAGE)
-        } else {
-            return saveFile(filePath)
-        }
-        return "Cannot continue saving the image."
-    }
-
-    private fun saveFile(filePath: String): String {
-        return try {
-            val tempFile = File(filePath)
-            val file = createFile(tempFile.extension)
-            tempFile.copyTo(file)
-
-            val uri = Uri.fromFile(file)
-            val context = registrar.activeContext().applicationContext
-            context.sendBroadcast(Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, uri))
-            uri.toString()
-        } catch (e: IOException) {
-            e.printStackTrace()
-            "Failed to save file to the gallery."
-        }
-    }
-
-    private fun createFile(extension: String = ""): File {
-        // TODO: Expose MethodChannel to allow custom path
-        // TODO: Expose MethodChannel to allow custom extensions
-        val path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES).absolutePath
-        val directory = File(path)
-        if (!directory.exists()) {
-            directory.mkdir()
-        }
-        var fileName = System.currentTimeMillis().toString()
-        if (extension.isNotEmpty()) {
-            fileName += ("." + extension)
-        }
-        return File(directory, fileName)
+    override fun onDetachedFromActivityForConfigChanges() {
+        this.mediaFileSaverPlugin = null
     }
 }

--- a/android/src/main/kotlin/com/freelancer/media_file_saver/MediaFileSaverPluginMethodChannel.kt
+++ b/android/src/main/kotlin/com/freelancer/media_file_saver/MediaFileSaverPluginMethodChannel.kt
@@ -1,0 +1,14 @@
+package com.freelancer.media_file_saver
+
+/**
+ * Created by Joshua de Guzman on 2020-01-07.
+ */
+
+enum class MediaFileSaverPluginMethodChannel constructor(private val str: String) {
+    SAVE_IMAGE("saveImage"),
+    SAVE_FILE("saveFile");
+
+    override fun toString(): String {
+        return this.str
+    }
+}


### PR DESCRIPTION
Migrate the plugin to utilize the latest plugin APIs and Flutter embedding V2. Please see docs [here](https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration).