### PR TITLE
Fixed authorisation issue for iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,9 +64,15 @@ class _MyHomePageState extends State<MyHomePage> {
       _imgUrl,
       options: Options(responseType: ResponseType.bytes),
     );
-    final result = await MediaFileSaver.saveImage(
+
+    bool result = await MediaFileSaver.saveImage(
       Uint8List.fromList(response.data),
     );
-    print("Saved path: $result");
+
+    if (result) {
+      print("Saved image");
+    } else {
+      print("Failed to save image");
+    }
   }
 }


### PR DESCRIPTION
# Description

I identified an issue with iOS where, when a user hasn't approved permission to the Photo Library and attempts to save a photo. After approving the image is not saved, however subsequent requests to save the image work as expected.

Along with this I refactored the Swift code.